### PR TITLE
Add quarto metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ arviz-plots @ git+https://github.com/arviz-devs/arviz-plots
 bambi @ git+https://github.com/bambinos/bambi
 kulprit @ git+https://github.com/bambinos/kulprit
 preliz==0.21.0
+pymc>=5.22.0
 pymc-bart @ git+https://github.com/pymc-devs/pymc-bart
 pymc-extras>=0.5.0
 scipy>=1.16.2


### PR DESCRIPTION
Adds personal info and fixes the build error with `pymc` versions