### PR TITLE
Fix date-modified metadata

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -32,8 +32,7 @@ book:
           postal-code: 15108
     - name: ArviZ-devs
       url: https://github.com/arviz-devs
-  date: 2025-04-02
-  date-modified: today
+  date: today
   favicon: favicon.ico
 
   chapters:
@@ -74,6 +73,8 @@ book:
 
 format:
   html:
+    date: 2025-04-02
+    date-modified: today
     toc: true
     code-line-numbers: true
     number-sections: true


### PR DESCRIPTION
Follow up fix to #195. The `date-modified` metadata key added there is html specific
but I added it to the global metadata fields.
