### PR TITLE
Isn't non-centered sampled more efficiently than centered?

### DIFF
--- a/Chapters/MCMC_diagnostics.qmd
+++ b/Chapters/MCMC_diagnostics.qmd
@@ -393,7 +393,7 @@ Additionally, if needed, we can specify the thinning factor manually by passing 
 
 Due to its internal workings, algorithms like NUTS offer some specific tests that are not available to other methods. These tests are generally very sensitive.
 
-To exemplify this we are going to load two InferenceData from pre-calculated models. The details of how these data were generated are not relevant at the moment. We will only say that they are two models that are mathematically equivalent but parameterized in different ways. In this case, the parameterization affects the efficiency of the sampler. The `centered` model is sampled more efficiently than the `non_centered` model.
+To exemplify this we are going to load two InferenceData from pre-calculated models. The details of how these data were generated are not relevant at the moment. We will only say that they are two models that are mathematically equivalent but parameterized in different ways. In this case, the parameterization affects the efficiency of the sampler. The `non_centered` model is sampled more efficiently than the `centered` model.
 
 ```{python}
 idata_cm = az.load_arviz_data("centered_eight")


### PR DESCRIPTION
Looking at Figure 4.12 and Figure 4.13, the non-centered model has higher and less varying BFMI. The centered model even has one chain with BFMI<0.3. In addition, the non-centered has marginal and transition distributions that almost overlap, whereas for the centered they are different. I hence wonder if these two labels should be swapped, and have suggested so in this PR.

<img width="1077" height="1042" alt="image" src="https://github.com/user-attachments/assets/054434d5-3dc4-4ce2-802c-12e2c0142775" />
